### PR TITLE
modified default PROXY, be consistent with byzer notebook backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BASE_URL=./
 VUE_APP_API_URL=/
-PROXY_SERVER=http://localhost:9090
+PROXY_SERVER=http://localhost:9002


### PR DESCRIPTION
This project is the frontend of byzer notebook, so the port should be consistent.